### PR TITLE
Add the possibility to only clean containers having a certain age

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Cecile Tonglet <cecile.tonglet@gmail.com>
 RUN apk update
 RUN apk add ca-certificates py-setuptools
 
-RUN easy_install-2.7 docker-py
+RUN easy_install-2.7 docker-py python-dateutil
 
 ADD /run.py /app/run.py
 

--- a/README.md
+++ b/README.md
@@ -21,3 +21,8 @@ docker run -it --rm \
  *  --loop-delay
 
     sleep a certain delay in seconds (0 to disable, this is the default)
+
+ * --min-age
+
+    only clean containers stopped since a certain time in seconds (0 to disable, this is the default)
+


### PR DESCRIPTION
You can now supply the '--min-age' command line option to specify the
minimum age (in seconds) containers should have existed to be cleaned
up.

For example, if you supply "--min-age 1800", the container-cleaner will
only clean containers having existed since al least 30 minutes.
